### PR TITLE
Fix CDK Constructs package version constraint

### DIFF
--- a/cdk/src/Cdk/Cdk.csproj
+++ b/cdk/src/Cdk/Cdk.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.CDK.Lib" Version="2.*" />
-    <PackageReference Include="Constructs" Version="[10.0.0,11.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
     <PackageReference Condition="'$(UseLocalBackendCommonCdk)' != 'true'" Include="WorldsOfTheNextRealm.BackendCommon.Cdk" Version="0.1.*" />
     <ProjectReference Condition="'$(UseLocalBackendCommonCdk)' == 'true'" Include="$(WotnrBackendCommonCdkProject)" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Changed `Constructs` package version in `cdk/src/Cdk/Cdk.csproj` from restrictive range `[10.0.0,11.0.0)` to `10.*`
- The old range caused a NuGet `NU1605` package downgrade error because `Amazon.CDK.Lib 2.239.0` requires `Constructs >= 10.5.0`, but the floor of `10.0.0` triggered a downgrade warning (treated as error)
- Aligns with BackendApi, NotificationService, and WorldSimulation CDK projects which all use `10.*`

## Test plan
- [x] `dotnet build` succeeds on the full solution (service + CDK + tests)
- [ ] Verify CDK synth still produces expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)