### PR TITLE
Pin .NET SDK to 8.0.x via global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `global.json` pinning SDK to 8.0.x with `rollForward: latestFeature`
- Prevents `ubuntu-latest` runner from using .NET 10 SDK which causes apphost build failures
- Matches the fix already applied to BackendCommon

## Test plan
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)